### PR TITLE
feat: 프로필 페이지 recoil 사용 및 로그아웃 로직

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,11 @@
 const nextConfig = {
   reactStrictMode: false,
   images: {
-    domains: ['media1.jjalkey.com', 'localhost'],
+    domains: [
+      'media1.jjalkey.com',
+      'localhost',
+      'example-bucket-seeun.s3.ap-northeast-2.amazonaws.com',
+    ],
   },
 };
 

--- a/src/containers/Profile/diaryModal.tsx
+++ b/src/containers/Profile/diaryModal.tsx
@@ -4,10 +4,10 @@ import Image from 'next/image';
 
 import '@/styles/profile/diaryModal.scss';
 import { useEffect, useState } from 'react';
+import { ProfileResultType } from '@/types';
 
 interface Props {
-  emoData: object;
-  // emoData: profileResultType;
+  emoData: ProfileResultType | null;
   modalDate: string;
 }
 
@@ -17,14 +17,16 @@ export default function DiaryModal({ emoData, modalDate }: Props) {
   const [isFront, setIsFront] = useState(true);
 
   useEffect(() => {
-    for (let key in emoData) {
-      if (key === modalDate) {
-        setDiaryPath(emoData[key].result.pictureDiary);
-        setGifPath(emoData[key].result.recommendedGif);
+    emoData?.calendar.map((el) => {
+      if (el.date === modalDate) {
+        setDiaryPath(el.result.pictureDiary);
+        setGifPath(el.result.recommendedGif);
       }
-    }
+    });
   }, [modalDate]);
 
+  // console.log(emoData);
+  console.log('path :: ', gifPath, diaryPath);
   const handleClick = () => {
     setIsFront(!isFront);
   };

--- a/src/containers/Profile/emoCalendar.tsx
+++ b/src/containers/Profile/emoCalendar.tsx
@@ -7,12 +7,13 @@ import moment from 'moment';
 import { GrCaretNext } from 'react-icons/gr';
 import { GrCaretPrevious } from 'react-icons/gr';
 import '@/styles/profile/_calendar.scss';
+import { ProfileResultType } from '@/types';
 // import Image from 'next/image';
 
 interface Props {
   setIsModalOpen: Dispatch<SetStateAction<boolean>>;
   setModalDate: Dispatch<SetStateAction<string>>;
-  emoData: object;
+  emoData: ProfileResultType | null;
 }
 
 export default function EmoCalendar({
@@ -21,18 +22,14 @@ export default function EmoCalendar({
   emoData,
 }: Props) {
   const [value, onChange] = useState<Date>(new Date()); // 클릭한 날짜 (초기값으로 현재 날짜 넣어줌)
+  const [dayList, setDayList] = useState<string[]>([]);
 
-  // const monthOfActiveDate = moment(value).format('YYYY-MM');
-  // const [activeMonth, setActiveMonth] = useState(monthOfActiveDate);
-
-  // const getActiveMonth = (activeStartDate: moment.MomentInput) => {
-  //   const newActiveMonth = moment(activeStartDate).format('YYYY-MM');
-  //   setActiveMonth(newActiveMonth);
-  // };
-
-  // console.log('변경된 날짜 :: ', value);
-
-  const dayList = Object.keys(emoData);
+  useEffect(() => {
+    const newDayList = emoData?.calendar?.map((el) => el.date);
+    if (newDayList) {
+      setDayList(newDayList);
+    }
+  }, [emoData]);
 
   // 각 날짜 타일에 컨텐츠 추가
   const addContent = ({ date }: any) => {

--- a/src/containers/Profile/index.tsx
+++ b/src/containers/Profile/index.tsx
@@ -104,11 +104,11 @@ export default function ProfilePage() {
               style={{ cursor: 'pointer' }}
               className="link"
               onClick={() => {
-                router.push('/');
+                router.push('/sigh');
               }}
             >
               <Link
-                href="/"
+                href="/sigh"
                 style={{ display: 'flex', alignItems: 'center', gap: '20px' }}
               >
                 한숨 쉬러 가기 <CiCircleChevRight />

--- a/src/containers/Profile/index.tsx
+++ b/src/containers/Profile/index.tsx
@@ -10,40 +10,39 @@ import DiaryModal from './diaryModal';
 import { useEffect, useRef, useState } from 'react';
 import PGraph from './profileGraph';
 import PRatio from './profileRatio';
-import { SighResultType } from '@/types';
+import { ProfileResultType } from '@/types';
 import { useRecoilState } from 'recoil'; // recoil
 import { userState } from '@/utils/state'; // recoil
 
 export default function ProfilePage() {
   const router = useRouter();
   const [modalDate, setModalDate] = useState<string>('');
-  // const [emoData, setEmoData] = useState<sighResultType[]>([]);
-  const [emoData, setEmoData] = useState({});
+  const [emoData, setEmoData] = useState<ProfileResultType | null>(null);
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const backgroundRef = useRef(null);
 
   const [user, setUser] = useRecoilState(userState); // recoil
-  useEffect(() => {
-    console.log(user);
-  }, []); // recoil
 
   const getUserInfo = async () => {
     try {
-      const res = await fetch('http://localhost:8080/profile/dashboard', {
-        cache: 'no-store',
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('token')}`,
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER}/profile/dashboard`,
+        {
+          cache: 'no-store',
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+          },
         },
-      });
+      );
 
       if (!res.ok) {
         throw new Error(`HTTP error! Status: ${res.status}`);
       }
 
-      const data = await res.json();
+      const data: ProfileResultType = await res.json();
       console.log('fetch data :: ', data);
 
       setEmoData(data);
@@ -53,8 +52,8 @@ export default function ProfilePage() {
   };
 
   useEffect(() => {
+    // console.log('로그인한 유저 :: ', user);
     getUserInfo();
-    // Call the function
   }, []);
 
   useEffect(() => {
@@ -84,11 +83,12 @@ export default function ProfilePage() {
         <div className="info-left">
           <p className="title">
             {/* {nickname}님, <br /> 오늘의 기분은 어떠신가요? */}
-            행복한 쿼카님, <br /> 오늘의 기분은 어떠신가요?
+            {user && `${user.nickname}님,`}
+            <br /> 오늘의 기분은 어떠신가요?
           </p>
           <div className="left-content">
             <div className="count">
-              <div>29</div>
+              <div>{emoData?.calendar?.length}</div>
               <div>
                 <p>THE NUMBER OF</p>
                 <p>SIGHS</p>

--- a/src/containers/Profile/index.tsx
+++ b/src/containers/Profile/index.tsx
@@ -20,10 +20,11 @@ export default function ProfilePage() {
   const [emoData, setEmoData] = useState<ProfileResultType | null>(null);
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-
   const backgroundRef = useRef(null);
 
-  const [user, setUser] = useRecoilState(userState); // recoil
+  // recoil -> 닉네임을 설정하기 위한 상태값 추가로 설정
+  const [user, setUser] = useRecoilState(userState);
+  const [nickname, setNickname] = useState('');
 
   const getUserInfo = async () => {
     try {
@@ -51,11 +52,12 @@ export default function ProfilePage() {
     }
   };
 
+  // 초기 렌더링 시 데이터 fetching
   useEffect(() => {
-    // console.log('로그인한 유저 :: ', user);
     getUserInfo();
   }, []);
 
+  // 모달창 외부 클릭 시 종료
   useEffect(() => {
     function handleClickOutside(this: Document, ev: MouseEvent): any {
       // 모달 바깥을 클릭하고, 모달이 열려있는 상태일 때 모달을 닫기
@@ -74,6 +76,10 @@ export default function ProfilePage() {
     };
   }, [isModalOpen]);
 
+  useEffect(() => {
+    setNickname(user.nickname);
+  }, []);
+
   return (
     <section className="profile-container">
       <div
@@ -83,7 +89,7 @@ export default function ProfilePage() {
         <div className="info-left">
           <p className="title">
             {/* {nickname}님, <br /> 오늘의 기분은 어떠신가요? */}
-            {user && `${user.nickname}님,`}
+            {nickname && `${nickname}님,`}
             <br /> 오늘의 기분은 어떠신가요?
           </p>
           <div className="left-content">

--- a/src/containers/common/header.tsx
+++ b/src/containers/common/header.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'react';
 
 export default function Header() {
   const [user, setUser] = useRecoilState(userState);
+  const resetUser = useResetRecoilState(userState);
   const [selectedIcon, setSelectedIcon] = useRecoilState(selectedIconState);
   const [selectedImage, setSelectedImage] = useRecoilState(selectedImageState);
 
@@ -25,7 +26,7 @@ export default function Header() {
   useEffect(() => {
     // console.log('user >>>>', user);
     user.isLogin ? setIsLogin(true) : setIsLogin(false);
-  }, [userState]); // recoil
+  }, [user.isLogin]); // recoil
 
   return (
     <header className="headerContainer">
@@ -46,13 +47,23 @@ export default function Header() {
           SIGN IN
         </Link>
       ) : (
-        <Link
-          href={'/profile'}
-          className="headerMenu signInBtn"
-          onClick={handleMenuBar}
-        >
-          profile
-        </Link>
+        <>
+          <Link
+            href={'/profile'}
+            className="headerMenu signInBtn"
+            onClick={handleMenuBar}
+          >
+            profile
+          </Link>
+          <div
+            onClick={() => {
+              resetUser()
+              localStorage.clear();
+            }}
+          >
+            로그아웃
+          </div>
+        </>
       )}
     </header>
   );

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -15,7 +15,7 @@ export interface ShopApiRes {
     category2: string;
     category3: string;
     category4: string;
-  }>
+  }>;
 }
 
 // diary result
@@ -32,11 +32,24 @@ export interface SighResultType {
   // date: Date;
 }
 
-// profile result (array)
-export type ProfileResultType = SighResultType[];
+// profile result
+export interface ProfileResultType {
+  calendar: {
+    date: string;
+    result: SighResultType;
+  }[];
+  error: null | string;
+  monthlyStatistics: {
+    [date: string]: {
+      positiveRatio: number;
+      negativeRatio: number;
+      neutralRatio: number;
+    };
+  };
+}
 
 // recoil user
-export interface IUserState {
+export interface UserStateType {
   userId: string;
   nickname: string;
   age: string;

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -1,10 +1,10 @@
 import { recoilPersist } from 'recoil-persist';
 import { atom } from 'recoil';
-import { IUserState } from '@/types';
+import { UserStateType } from '@/types';
 
 const { persistAtom } = recoilPersist();
 
-const userState = atom<IUserState>({
+const userState = atom<UserStateType>({
   key: 'userState',
   default: {
     userId: '',
@@ -27,4 +27,3 @@ const selectedImageState = atom({
 });
 
 export { userState, selectedIconState, selectedImageState };
-


### PR DESCRIPTION
1. recoil 사용해서 프로필 페이지 한숨 횟수 표시: 이 때 recoil 값 바로 쓰면 hydration 에러 나서 useEffect 사용해서 처리. 따라서 상태값 하나 더 추가해서 사용(useState)
2. 헤더에 로그아웃 로직만 구현해놓음. 디자인은 따로 진행해야함