### PR TITLE
feat: refresh 로직 구현

### DIFF
--- a/src/containers/Profile/profileRatio.tsx
+++ b/src/containers/Profile/profileRatio.tsx
@@ -62,6 +62,10 @@ export default function PRatio() {
         } else {
           console.error('Invalid data types for ratios');
         }
+      } else if (res.status === 405) {
+        console.error('액세스 토큰 만료됐을듯?');
+      } else {
+        console.error('완전 다른 에러');
       }
     } catch (error) {
       console.error(error);
@@ -69,11 +73,7 @@ export default function PRatio() {
   };
 
   useEffect(() => {
-    responseInterceptor();
-    // console.log('인터셉터 실행!!!');
-
     getData();
-    // console.log('getData 실행!!!!');
   }, []);
 
   return (

--- a/src/containers/common/header.tsx
+++ b/src/containers/common/header.tsx
@@ -10,6 +10,7 @@ import {
   selectedImageState,
 } from '@/utils/state';
 import { useEffect, useState } from 'react';
+import responseInterceptor from '@/utils/fetch';
 
 export default function Header() {
   const router = useRouter();
@@ -29,6 +30,11 @@ export default function Header() {
     // console.log('user >>>>', user);
     user.isLogin ? setIsLogin(true) : setIsLogin(false);
   }, [user.isLogin]); // recoil
+
+  useEffect(() => {
+    // access token 만료됐는지 검증하는 interceptor
+    responseInterceptor();
+  }, []);
 
   return (
     <header className="headerContainer">

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,45 +1,90 @@
 export default function responseInterceptor() {
   // request interceptor test
-  const { fetch: originalFetch } = window;
-  window.fetch = async (...args) => {
-    // 리소스, 옵션 분리
-    let [resource, options] = args;
-    console.log('resource :: ', resource);
-    console.log('options :: ', options);
 
-    // 원래 fetch 실행 (응답 가로챌거니까)
-    console.log('원래 fetch 실행!!!!');
-    const response: Response = await originalFetch(resource, options);
-    if (response.status === 401) {
-      const res2 = await fetch(
-        `${process.env.NEXT_PUBLIC_API_SERVER}/auth/newToken`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
-          },
-        },
-      );
-      if (res2.status === 200 || res2.status === 201) {
-        const data = await res2.json();
-        const newAccessToken = data.accessToken;
-        localStorage.removeItem('accessToken');
-        console.log('액세스 삭제 완료');
-        localStorage.setItem('accessToken', newAccessToken);
-        console.log('액세스 재설정 완료');
-        console.log('액세스 바꾸고 재실행!!!');
+  // Client Side
+  if (typeof window !== undefined) {
+    // 토큰 값 해석해서 만료일 계산
+    const accessToken = localStorage.getItem('accessToken');
+    const refreshToken = localStorage.getItem('refreshToken');
 
-        const result: Response = await originalFetch(resource, {
-          ...options,
-          headers: { Authorization: `Bearer ${newAccessToken}` },
-        });
-        return result;
+    const { fetch: originalFetch } = window;
+    window.fetch = async (...args) => {
+      // 리소스, 옵션 분리
+      let [resource, options] = args;
+      console.log('resource :: ', resource);
+      console.log('options :: ', options);
+
+      if (accessToken && refreshToken) {
+        const aBase64Url = accessToken.split('.')[1];
+        const aBase64 = aBase64Url.replace('-', '+').replace('_', '/');
+        const { exp: aExp } = JSON.parse(window.atob(aBase64));
+        const now = Date.now();
+        // console.log('시간 비교', aExp, +now.toString().slice(0, 10));
+
+        // 액세스 토큰 재발급 요청 전에 리프레시 만료 전인지 확인
+
+        const isRefreshValid = isRefreshTokenExpired(refreshToken, now);
+        if (isRefreshValid) {
+          // 리프레시는 살아잇음 -> 액세스만 확인
+          // 만료일과 현재 시간 비교
+
+          if (aExp > +now.toString().slice(0, 10)) {
+            // 만료
+            // 액세스 토큰 재발급 요청
+            const refreshRes = await fetch(
+              `${process.env.NEXT_PUBLIC_API_SERVER}/auth/newToken`,
+              {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${refreshToken}` },
+              },
+            );
+            if (refreshRes.status === 200 || refreshRes.status === 201) {
+              const data = await refreshRes.json();
+              const newAccessToken = data.accessToken;
+              localStorage.removeItem('accessToken');
+              console.log('액세스 삭제 완료');
+              localStorage.setItem('accessToken', newAccessToken);
+              console.log('액세스 재설정 완료');
+
+              console.log('액세스 바꾸고 재실행!!!');
+              const result: Response = await originalFetch(resource, {
+                ...options,
+                headers: { Authorization: `Bearer ${newAccessToken}` },
+              });
+              return result;
+            } else {
+              // 새로운 access token 발급 요청에 대한 응답을 반환
+              return refreshRes;
+            }
+          } else {
+            // 만료 안됨 -> 원래 로직
+            const originalRes = await originalFetch(resource, options);
+            return originalRes;
+          }
+        } else {
+          // 둘다 만료
+          const noAuth = new Response('noAuth', {
+            status: 1001,
+            headers: { 'Content-type': 'application/json' },
+          });
+          return noAuth;
+        }
       } else {
-        // 로그아웃 시켜야함
-        return response;
+        const noAccessTokenRes = new Response('noAccessToken', {
+          status: 1000,
+          headers: { 'Content-type': 'application/json' },
+        });
+        return noAccessTokenRes;
       }
-    } else {
-      return response;
-    }
-  };
+    };
+  }
 }
+
+const isRefreshTokenExpired = (refreshToken: string, now: number) => {
+  // 리프레시는 만료 안됐는지 검증
+  const rBase64Url = refreshToken.split('.')[1];
+  const rBase64 = rBase64Url.replace('-', '+').replace('_', '/');
+  const { exp: rExp } = JSON.parse(window.atob(rBase64));
+
+  return rExp < +now.toString().slice(0, 10) ? false : true;
+};

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,90 +1,48 @@
 export default function responseInterceptor() {
   // request interceptor test
+  const { fetch: originalFetch } = window;
+  window.fetch = async (...args) => {
+    // 리소스, 옵션 분리
+    let [resource, options] = args;
+    console.log('resource :: ', resource);
+    console.log('options :: ', options);
 
-  // Client Side
-  if (typeof window !== undefined) {
-    // 토큰 값 해석해서 만료일 계산
-    const accessToken = localStorage.getItem('accessToken');
-    const refreshToken = localStorage.getItem('refreshToken');
+    // 원래 fetch 실행 (응답 가로챌거니까)
+    console.log('원래 fetch 실행!!!!');
+    const response: Response = await originalFetch(resource, options);
+    if (response.status === 401) {
+      const res2 = await fetch(
+        `${process.env.NEXT_PUBLIC_API_SERVER}/auth/newToken`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('refreshToken')}`,
+          },
+        },
+      );
+      if (res2.status === 200 || res2.status === 201) {
+        const data = await res2.json();
+        const newAccessToken = data.accessToken;
+        localStorage.removeItem('accessToken');
+        console.log('액세스 삭제 완료');
+        localStorage.setItem('accessToken', newAccessToken);
+        console.log('액세스 재설정 완료');
+        console.log('액세스 바꾸고 재실행!!!');
 
-    const { fetch: originalFetch } = window;
-    window.fetch = async (...args) => {
-      // 리소스, 옵션 분리
-      let [resource, options] = args;
-      console.log('resource :: ', resource);
-      console.log('options :: ', options);
-
-      if (accessToken && refreshToken) {
-        const aBase64Url = accessToken.split('.')[1];
-        const aBase64 = aBase64Url.replace('-', '+').replace('_', '/');
-        const { exp: aExp } = JSON.parse(window.atob(aBase64));
-        const now = Date.now();
-        // console.log('시간 비교', aExp, +now.toString().slice(0, 10));
-
-        // 액세스 토큰 재발급 요청 전에 리프레시 만료 전인지 확인
-
-        const isRefreshValid = isRefreshTokenExpired(refreshToken, now);
-        if (isRefreshValid) {
-          // 리프레시는 살아잇음 -> 액세스만 확인
-          // 만료일과 현재 시간 비교
-
-          if (aExp > +now.toString().slice(0, 10)) {
-            // 만료
-            // 액세스 토큰 재발급 요청
-            const refreshRes = await fetch(
-              `${process.env.NEXT_PUBLIC_API_SERVER}/auth/newToken`,
-              {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${refreshToken}` },
-              },
-            );
-            if (refreshRes.status === 200 || refreshRes.status === 201) {
-              const data = await refreshRes.json();
-              const newAccessToken = data.accessToken;
-              localStorage.removeItem('accessToken');
-              console.log('액세스 삭제 완료');
-              localStorage.setItem('accessToken', newAccessToken);
-              console.log('액세스 재설정 완료');
-
-              console.log('액세스 바꾸고 재실행!!!');
-              const result: Response = await originalFetch(resource, {
-                ...options,
-                headers: { Authorization: `Bearer ${newAccessToken}` },
-              });
-              return result;
-            } else {
-              // 새로운 access token 발급 요청에 대한 응답을 반환
-              return refreshRes;
-            }
-          } else {
-            // 만료 안됨 -> 원래 로직
-            const originalRes = await originalFetch(resource, options);
-            return originalRes;
-          }
-        } else {
-          // 둘다 만료
-          const noAuth = new Response('noAuth', {
-            status: 1001,
-            headers: { 'Content-type': 'application/json' },
-          });
-          return noAuth;
-        }
-      } else {
-        const noAccessTokenRes = new Response('noAccessToken', {
-          status: 1000,
-          headers: { 'Content-type': 'application/json' },
+        const result: Response = await originalFetch(resource, {
+          ...options,
+          headers: {
+            Authorization: `Bearer ${newAccessToken}`,
+            'Content-Type': 'application/json',
+          },
         });
-        return noAccessTokenRes;
+        return result;
+      } else {
+        // 로그아웃 시켜야함
+        return response;
       }
-    };
-  }
+    } else {
+      return response;
+    }
+  };
 }
-
-const isRefreshTokenExpired = (refreshToken: string, now: number) => {
-  // 리프레시는 만료 안됐는지 검증
-  const rBase64Url = refreshToken.split('.')[1];
-  const rBase64 = rBase64Url.replace('-', '+').replace('_', '/');
-  const { exp: rExp } = JSON.parse(window.atob(rBase64));
-
-  return rExp < +now.toString().slice(0, 10) ? false : true;
-};


### PR DESCRIPTION
1. 기존 요청대로 fetch 쓰면 됨.
2. 토큰을 클라이언트 사이드에서 관리하니 체크하는 로직을 클라이언트 사이드로 구현
3. header component 가 모든 페이지에서 공통 컴포넌트라서 responseInterceptor 함수를 header 컴포넌트 useEffect 부분에서 불러옴
4. 다른 클라 사이드 페이지에서 따로 적용할 거 없이 그냥 요청 날리면 됨!
5. 수정 부분
[before]
액세스 토큰 갱신 후 헤더에 Bearer accessToken 만 설정
[after]
accessToken + content type: application/json 까지 추가